### PR TITLE
fix: removeNavigationUpdates was treated like a sync function, but it…

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -460,7 +460,7 @@ export default class SitumPlugin {
    *
    */
   static removeNavigationUpdates = () => {
-    return exceptionWrapper<void>(({ onCallback }) => {
+    return promiseWrapper<void>(({ onCallback }) => {
       if (!SitumPlugin.navigationIsRunning()) {
         throw "Situm > hook > Navigation updates were not active.";
       }

--- a/src/wayfinding/hooks/index.ts
+++ b/src/wayfinding/hooks/index.ts
@@ -225,13 +225,14 @@ export const useSitumInternal = () => {
       return;
     }
 
-    try {
-      SitumPlugin.removeNavigationUpdates();
-      console.debug("Situm > hook > Successfully removed navigation updates");
-      dispatch(setNavigation({ status: NavigationStatus.STOP }));
-    } catch (e) {
-      console.error(`Situm > hook > Could not remove navigation updates ${e}`);
-    }
+    SitumPlugin.removeNavigationUpdates()
+      .then(() => {
+        console.debug("Situm > hook > Successfully removed navigation updates");
+        dispatch(setNavigation({ status: NavigationStatus.STOP }));
+      })
+      .catch((e) => {
+        console.warn(`Situm > hook > Could not remove navigation updates ${e}`);
+      });
   };
 
   return {


### PR DESCRIPTION
… should be async

Because of this, Android generated an uncaught exception (essentially, the try/catch block finished and after that the exception was raised) when the user finished the route. At least in debug mode, this caused a critical error.