### PR TITLE
feature/tts

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -491,21 +491,23 @@ PODS:
     - React-jsi (= 0.72.12)
     - React-logger (= 0.72.12)
     - React-perflogger (= 0.72.12)
-  - ReactNativeSitumPlugin (3.5.16):
+  - ReactNativeSitumPlugin (3.7.4):
     - RCT-Folly (= 2021.07.22.00)
     - React
     - React-Core
-    - SitumSDK (= 3.10.0)
+    - SitumSDK (= 3.12.0)
   - RNPermissions (3.10.1):
     - React-Core
   - RNScreens (3.30.1):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - SitumSDK (3.10.0):
+  - SitumSDK (3.12.0):
     - Protobuf (~> 3.7)
     - SSZipArchive (~> 2.4)
   - SocketRocket (0.6.1)
   - SSZipArchive (2.4.3)
+  - TextToSpeech (4.1.0):
+    - React
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -578,6 +580,7 @@ DEPENDENCIES:
   - ReactNativeSitumPlugin (from `../..`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNScreens (from `../node_modules/react-native-screens`)
+  - TextToSpeech (from `../node_modules/react-native-tts`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -687,6 +690,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-permissions"
   RNScreens:
     :path: "../node_modules/react-native-screens"
+  TextToSpeech:
+    :path: "../node_modules/react-native-tts"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -744,12 +749,13 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 8aea338c561b2175f47018124c076d89d3808d30
   React-utils: 9a24cb88f950d1020ee55bddacbc8c16a611e2dc
   ReactCommon: 76843a9bb140596351ac2786257ac9fe60cafabb
-  ReactNativeSitumPlugin: f7c8c3508707c2ab7c26bcd8dc9886346adc3bf8
+  ReactNativeSitumPlugin: 83d0cba010c93d09395f8a19c90c6a93198faff4
   RNPermissions: d9189887d0589d4e4f504836cb94f905b68b0a7d
   RNScreens: e5ee7223f7c8fa261f0c4594a0541c56ea99bbfc
-  SitumSDK: 462cb3f36a67739f2907f41997f0d187246f1468
+  SitumSDK: 3a934488382898f9dbb7fd1d9ff54d7b4cff6ebf
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
+  TextToSpeech: b3aa777ff5585705f179c0a2436bfd0926d1716e
   Yoga: 87e59f6d458e5061d2421086c5de994b3f7cd151
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/example/package.json
+++ b/example/package.json
@@ -21,6 +21,7 @@
     "react-native-permissions": "^3.8.3",
     "react-native-safe-area-context": "^4.4.1",
     "react-native-screens": "^3.18.2",
+    "react-native-tts": "^4.1.0",
     "react-native-webview": "^13.2.2"
   },
   "devDependencies": {

--- a/example/src/examples/wayfinding/Wayfinding.tsx
+++ b/example/src/examples/wayfinding/Wayfinding.tsx
@@ -1,4 +1,6 @@
 import React, {useEffect, useState, useRef} from 'react';
+import Tts from 'react-native-tts';
+
 import {
   AppState,
   NativeEventSubscription,
@@ -133,6 +135,10 @@ const Screen: React.FC = () => {
     console.log('Situm > example > click on external link: ' + event.url);
   };
 
+  const onSpeakAloudText = (event: OnSpeakAloudTextResult) => {
+    Tts.speak(event.text);
+  };
+
   return (
     <MapView
       ref={mapViewRef}
@@ -144,6 +150,7 @@ const Screen: React.FC = () => {
       onPoiSelected={onPoiSelected}
       onPoiDeselected={onPoiDeselected}
       onExternalLinkClicked={onExternalLinkClicked}
+      onSpeakAloudText={onSpeakAloudText}
     />
   );
 };

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1850,7 +1850,7 @@
     "@sinonjs/commons" "^3.0.0"
 
 "@situm/react-native@file:..":
-  version "3.5.16"
+  version "3.7.4"
   dependencies:
     react-dom "^18.2.0"
     react-native-permissions "^3.8.4"
@@ -5753,6 +5753,11 @@ react-native-screens@^3.18.2:
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
+
+react-native-tts@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-tts/-/react-native-tts-4.1.0.tgz#05fa34492bec234bcd64f6ed2bf122c4667d141a"
+  integrity sha512-tvf3lQ6u9MqztUie37qoPw5YQPqi0ql1lPhDsBBs/RRA6A/H1J9X9H/qb1A0Hx0ZpjavrEdtVSqQQ2JDZvZCTQ==
 
 react-native-webview@*, react-native-webview@^13.2.2:
   version "13.8.5"

--- a/src/wayfinding/components/MapView.tsx
+++ b/src/wayfinding/components/MapView.tsx
@@ -34,6 +34,7 @@ import {
   type OnFloorChangedResult,
   type OnPoiDeselectedResult,
   type OnPoiSelectedResult,
+  type OnSpeakAloudTextResult,
   type SearchFilter,
 } from "../types";
 import { ErrorName } from "../types/constants";
@@ -135,6 +136,12 @@ export interface MapViewProps {
    * @param event {@link OnFavoritePoisUpdatedResult} object.
    */
   onFavoritePoisUpdated?: (event: OnFavoritePoisUpdatedResult) => void;
+  /**
+   * Callback invoked when the map needs the third party integrator to speak
+   * aloud some text.
+   * @param event {@link OnSpeakAloudText} object.
+   */
+  onSpeakAloudText?: (event: OnSpeakAloudTextResult) => void;
 }
 
 const MapView = React.forwardRef<MapViewRef, MapViewProps>(
@@ -149,6 +156,7 @@ const MapView = React.forwardRef<MapViewRef, MapViewProps>(
       onFloorChanged = () => {},
       onExternalLinkClicked = undefined,
       onFavoritePoisUpdated = () => {},
+      onSpeakAloudText = () => {},
     },
     ref
   ) => {
@@ -451,6 +459,11 @@ const MapView = React.forwardRef<MapViewRef, MapViewProps>(
               : [],
           };
           onFavoritePoisUpdated(favoritePoisIds);
+          break;
+        }
+        case "ui.speak_aloud_text": {
+          onSpeakAloudText(eventParsed.payload.text);
+
           break;
         }
         case "cartography.floor_selected":

--- a/src/wayfinding/types/index.ts
+++ b/src/wayfinding/types/index.ts
@@ -128,6 +128,13 @@ export interface OnFavoritePoisUpdatedResult {
   currentPoisIdentifiers: number[];
 }
 
+export interface OnSpeakAloudTextResult {
+  /**
+   * Text that must be speak aloud.
+   */
+  text: string;
+}
+
 export interface Destination {
   category: string;
   identifier?: string;


### PR DESCRIPTION
This pull request adds support a new prop `onSpeakAloudText()` in the <MapView> component.

This new callback allows integrators to use their own implementation of Text-To-Speech without adding hard dependency on TTS third party libraries on our React Native plugin.

A reference implementation is been added to the example app.